### PR TITLE
[Feat] socialLogin - kakao, naver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,22 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     //https://mvnrepository.com/artifact/io.springfox/springfox-swagger-ui
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+// https://mvnrepository.com/artifact/com.google.code.gson/gson
+    implementation 'com.google.code.gson:gson:2.8.5'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'com.h2database:h2'
 }

--- a/src/main/java/org/diamond_badge/footprint/FootprintApplication.java
+++ b/src/main/java/org/diamond_badge/footprint/FootprintApplication.java
@@ -2,12 +2,19 @@ package org.diamond_badge.footprint;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class FootprintApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(FootprintApplication.class, args);
+	}
+
+	@Bean
+	public RestTemplate getRestTemplate() {
+		return new RestTemplate();
 	}
 
 }

--- a/src/main/java/org/diamond_badge/footprint/advice/ExceptionAdvice.java
+++ b/src/main/java/org/diamond_badge/footprint/advice/ExceptionAdvice.java
@@ -2,6 +2,10 @@ package org.diamond_badge.footprint.advice;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.diamond_badge.footprint.advice.exception.ComunicationException;
+import org.diamond_badge.footprint.advice.exception.InvalidRefreshTokenException;
+import org.diamond_badge.footprint.advice.exception.NotExpiredTokenYetException;
+import org.diamond_badge.footprint.advice.exception.UserNotFoundException;
 import org.diamond_badge.footprint.model.CommonResult;
 import org.diamond_badge.footprint.service.ResponseService;
 import org.springframework.http.HttpStatus;
@@ -20,5 +24,29 @@ public class ExceptionAdvice {
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	protected CommonResult defaultException(HttpServletRequest request,Exception e){
 		return responseService.getFailResult(500,"실패");
+	}
+
+	@ExceptionHandler(UserNotFoundException.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	protected CommonResult userNotFoundException(HttpServletRequest request, UserNotFoundException e) {
+		return responseService.getFailResult(HttpStatus.NOT_FOUND.value(), "사용자가 존재하지 않습니다.");
+	}
+
+	@ExceptionHandler(ComunicationException.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	protected CommonResult comunicationException(HttpServletRequest request, ComunicationException e) {
+		return responseService.getFailResult(HttpStatus.INTERNAL_SERVER_ERROR.value(), "통신 중 오류가 발생했습니다.");
+	}
+
+	@ExceptionHandler(NotExpiredTokenYetException.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	protected CommonResult notExpiredTokenYetException(HttpServletRequest request, NotExpiredTokenYetException e) {
+		return responseService.getFailResult(HttpStatus.BAD_REQUEST.value(), "아직 유효한 토큰입니다.");
+	}
+
+	@ExceptionHandler(InvalidRefreshTokenException.class)
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	protected CommonResult invalidRefreshTokenException(HttpServletRequest request, InvalidRefreshTokenException e) {
+		return responseService.getFailResult(HttpStatus.NOT_FOUND.value(), "유효하지않은 Refresh Token 입니다.");
 	}
 }

--- a/src/main/java/org/diamond_badge/footprint/advice/exception/ComunicationException.java
+++ b/src/main/java/org/diamond_badge/footprint/advice/exception/ComunicationException.java
@@ -1,0 +1,15 @@
+package org.diamond_badge.footprint.advice.exception;
+
+public class ComunicationException extends RuntimeException {
+	public ComunicationException() {
+		super();
+	}
+
+	public ComunicationException(String message) {
+		super(message);
+	}
+
+	public ComunicationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/advice/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/org/diamond_badge/footprint/advice/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package org.diamond_badge.footprint.advice.exception;
+
+public class InvalidRefreshTokenException extends RuntimeException{
+	public InvalidRefreshTokenException() {
+	}
+
+	public InvalidRefreshTokenException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/advice/exception/NotExpiredTokenYetException.java
+++ b/src/main/java/org/diamond_badge/footprint/advice/exception/NotExpiredTokenYetException.java
@@ -1,0 +1,10 @@
+package org.diamond_badge.footprint.advice.exception;
+
+public class NotExpiredTokenYetException extends RuntimeException{
+	public NotExpiredTokenYetException() {
+	}
+
+	public NotExpiredTokenYetException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/advice/exception/UserNotFoundException.java
+++ b/src/main/java/org/diamond_badge/footprint/advice/exception/UserNotFoundException.java
@@ -1,0 +1,15 @@
+package org.diamond_badge.footprint.advice.exception;
+
+public class UserNotFoundException extends RuntimeException {
+	public UserNotFoundException(String msg, Throwable t) {
+		super(msg, t);
+	}
+
+	public UserNotFoundException(String msg) {
+		super(msg);
+	}
+
+	public UserNotFoundException() {
+		super();
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/config/WebSecurityConfig.java
+++ b/src/main/java/org/diamond_badge/footprint/config/WebSecurityConfig.java
@@ -1,0 +1,85 @@
+package org.diamond_badge.footprint.config;
+
+import org.diamond_badge.footprint.config.security.CustomAuthenticationEntryPoint;
+import org.diamond_badge.footprint.config.security.JwtAuthenticationFilter;
+import org.diamond_badge.footprint.config.security.JwtTokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @package : kr.or.dining_together.member.config
+ * @name: WebSecurityConfig.java
+ * @date : 2021/05/26 12:45 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : 스프링 시큐리티 설정 파일
+ * @modified :
+ **/
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Bean
+	@Override
+	protected AuthenticationManager authenticationManager() throws Exception {
+		return super.authenticationManager();
+	}
+
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http.httpBasic().disable()    // security에서 기본으로 생성하는 login페이지 사용 안 함
+			.csrf().disable()    // REST API 사용하기 때문에 csrf 사용 안 함
+			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)    // JWT인증사용하므로 세션 생성 안함
+			// .and()
+			// .authorizeRequests() // 다음 리퀘스트에 대한 사용권한 체크
+			// .antMatchers("/auth/**", "/*/user/registeration", "/h2-console/**").permitAll() // 가입 및 인증 주소는 누구나 접근가능
+			// .anyRequest().hasRole("USER") // 그외 나머지 요청은 모두 인증된 회원만 접근 가능
+			.and()
+			.exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+			.and()
+			.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+	}
+
+	@Bean   // CORS 정책 설정
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+
+		configuration.addAllowedOrigin("*");
+		configuration.addAllowedHeader("*");
+		configuration.addAllowedMethod("*");
+		configuration.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
+
+	// swagger 사용할 시 추가
+	@Override
+	public void configure(WebSecurity web) {
+		web.ignoring().antMatchers("/v2/api-docs",
+			"/configuration/ui",
+			"/swagger-resources/**",
+			"/configuration/security",
+			"/swagger-ui.html",
+			"/webjars/**",
+			"/h2-console/**");
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/diamond_badge/footprint/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package org.diamond_badge.footprint.config.security;
+
+import java.io.IOException;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException exception) throws
+		IOException,
+		ServletException {
+		RequestDispatcher dispatcher = request.getRequestDispatcher("/exception/accessdenied");
+		dispatcher.forward(request, response);
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/diamond_badge/footprint/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package org.diamond_badge.footprint.config.security;
+
+import java.io.IOException;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException ex) throws
+		IOException,
+		ServletException {
+		RequestDispatcher dispatcher = request.getRequestDispatcher("/exception/entrypoint");
+		dispatcher.forward(request, response);
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/diamond_badge/footprint/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,36 @@
+package org.diamond_badge.footprint.config.security;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+	private JwtTokenProvider jwtTokenProvider;
+
+	// Jwt Provier 주입
+	public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+		this.jwtTokenProvider = jwtTokenProvider;
+	}
+
+	// Request로 들어오는 Jwt Token의 유효성을 검증(jwtTokenProvider.validateToken)하는 filter를 filterChain에 등록합니다.
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws
+		IOException,
+		ServletException {
+		String token = jwtTokenProvider.resolveToken((HttpServletRequest)request);
+		if (token != null && jwtTokenProvider.validateToken(token)) {
+			Authentication auth = jwtTokenProvider.getAuthentication(token);
+			SecurityContextHolder.getContext().setAuthentication(auth);
+		}
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/config/security/JwtTokenProvider.java
+++ b/src/main/java/org/diamond_badge/footprint/config/security/JwtTokenProvider.java
@@ -1,0 +1,115 @@
+package org.diamond_badge.footprint.config.security;
+
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+
+import org.diamond_badge.footprint.jpa.entity.RoleType;
+import org.springframework.core.env.Environment;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+	private final Environment env;
+	private final UserDetailsService userDetailsService;
+	private String SECRET_KEY;
+
+	private long EXPIRATION_TIME;
+	private long REFRESH_EXPIRATION;
+
+	@PostConstruct
+	protected void init() {
+		SECRET_KEY = Base64.getEncoder().encodeToString(env.getProperty("spring.jwt.secret").getBytes());
+		EXPIRATION_TIME = Long.parseLong(env.getProperty("spring.jwt.expiration_time"));
+		REFRESH_EXPIRATION=Long.parseLong(env.getProperty("spring.jwt.refreshTokenExpiry"));
+
+	}
+
+	// Jwt 토큰 생성
+	public String createToken(String userPk, RoleType roles) {
+		Claims claims = Jwts.claims().setSubject(userPk);
+		claims.put("roles", roles);
+		Date now = new Date();
+		return Jwts.builder()
+			.setClaims(claims) // 데이터
+			.setIssuedAt(now) // 토큰 발행일자
+			.setExpiration(new Date(now.getTime() + EXPIRATION_TIME)) // set Expire Time
+			.signWith(SignatureAlgorithm.HS256, SECRET_KEY) // 암호화 알고리즘, secret값 세팅
+			.compact();
+	}
+
+
+	// Jwt 토큰 생성
+	public String createRefreshToken(String userPk, RoleType roles) {
+		Claims claims = Jwts.claims().setSubject(userPk);
+		claims.put("roles", roles);
+		Date now = new Date();
+		return Jwts.builder()
+			.setClaims(claims) // 데이터
+			.setIssuedAt(now) // 토큰 발행일자
+			.setExpiration(new Date(now.getTime() + REFRESH_EXPIRATION)) // set Expire Time
+			.signWith(SignatureAlgorithm.HS256, SECRET_KEY) // 암호화 알고리즘, secret값 세팅
+			.compact();
+	}
+	// Jwt 토큰으로 인증 정보를 조회
+	public Authentication getAuthentication(String token) {
+		UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserPk(token));
+		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+	}
+
+	// Jwt 토큰에서 회원 구별 정보 추출
+	public String getUserPk(String token) {
+		return Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token).getBody().getSubject();
+	}
+
+	public long getREFRESH_EXPIRATION(){
+		return REFRESH_EXPIRATION;
+	}
+
+	// Request의 Header에서 token 파싱 : "X-AUTH-TOKEN: jwt토큰"
+	public String resolveToken(HttpServletRequest req) {
+		return req.getHeader("Authorization");
+	}
+
+	// Jwt 토큰의 유효성 + 만료일자 확인
+	public boolean validateToken(String jwtToken) {
+		try {
+			Jws<Claims> claims = Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(jwtToken);
+			return !claims.getBody().getExpiration().before(new Date());
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	public Claims getExpiredTokenClaims(String jwtToken) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(SECRET_KEY)
+				.build()
+				.parseClaimsJws(jwtToken)
+				.getBody();
+		} catch (ExpiredJwtException e) {
+			log.info("Expired JWT token.");
+			return e.getClaims();
+		}
+		return null;
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/controller/SignController.java
+++ b/src/main/java/org/diamond_badge/footprint/controller/SignController.java
@@ -1,0 +1,146 @@
+package org.diamond_badge.footprint.controller;
+
+import java.util.Date;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.diamond_badge.footprint.advice.exception.InvalidRefreshTokenException;
+import org.diamond_badge.footprint.advice.exception.NotExpiredTokenYetException;
+import org.diamond_badge.footprint.config.security.JwtTokenProvider;
+import org.diamond_badge.footprint.jpa.entity.RoleType;
+import org.diamond_badge.footprint.jpa.entity.User;
+import org.diamond_badge.footprint.jpa.entity.UserRefreshToken;
+import org.diamond_badge.footprint.jpa.repo.UserRefreshTokenRepository;
+import org.diamond_badge.footprint.model.SingleResult;
+import org.diamond_badge.footprint.model.social.RetKakaoAuth;
+import org.diamond_badge.footprint.model.social.RetNaverAuth;
+import org.diamond_badge.footprint.service.KakaoService;
+import org.diamond_badge.footprint.service.NaverService;
+import org.diamond_badge.footprint.service.ResponseService;
+import org.diamond_badge.footprint.service.UserService;
+import org.diamond_badge.footprint.util.CookieUtil;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.jsonwebtoken.Claims;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+
+import lombok.RequiredArgsConstructor;
+
+
+@Api(tags = {"1. Sign"})
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "/api/v1/auth")
+public class SignController {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final ResponseService responseService;
+	private final UserService userService;
+	private final KakaoService kakaoService;
+	private final NaverService naverService;
+	private final UserRefreshTokenRepository userRefreshTokenRepository;
+	private final static long THREE_DAYS_MSEC = 259200000;
+	private final static String REFRESH_TOKEN = "refresh_token";
+
+	@ApiOperation(value = "소셜 로그인", notes = " 소셜 회원 로그인을 한다.")
+	@PostMapping(value = "/signin/{provider}")
+	public SingleResult<String> signinByProvider(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		@ApiParam(value = "서비스 제공자 provider", required = true, defaultValue = "kakao") @PathVariable String provider,
+		@ApiParam(value = "소셜 인가 코드", required = true) @RequestParam String code) {
+
+		User signedUser = null;
+
+		switch (provider) {
+			case "naver":
+				RetNaverAuth retNaverAuth=naverService.getNaverTokenInfo(code);
+				signedUser = userService.signupByNaver(retNaverAuth.getAccess_token(), provider);
+				break;
+			case "kakao":
+				RetKakaoAuth retKakaoAuth = kakaoService.getKakaoTokenInfo(code);
+				signedUser = userService.signupByKakao(retKakaoAuth.getAccess_token(), provider);
+				break;
+		}
+
+		String refreshToken= jwtTokenProvider.createRefreshToken(String.valueOf(signedUser.getEmail()), signedUser.getRoleType());
+
+		UserRefreshToken userRefreshToken=userRefreshTokenRepository.findByUserEmail(signedUser.getEmail());
+		if(userRefreshToken==null){
+			userRefreshToken=new UserRefreshToken(signedUser.getEmail(),refreshToken);
+			userRefreshTokenRepository.saveAndFlush(userRefreshToken);
+		}else{
+			userRefreshToken.setRefreshToken(refreshToken);
+		}
+		long refreshTokenExpiry= jwtTokenProvider.getREFRESH_EXPIRATION();
+		int cookieMaxAge = (int) refreshTokenExpiry / 60;
+		CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+		CookieUtil.addCookie(response, REFRESH_TOKEN, refreshToken, cookieMaxAge);
+
+		return responseService.getSingleResult(
+			jwtTokenProvider.createToken(String.valueOf(signedUser.getEmail()), signedUser.getRoleType()));
+
+	}
+
+	@ApiOperation(value="refreshToken 값 -> AccessToken 값",notes = "refreshToken 값을 이용해 AccessToken 값을 얻는다")
+	@GetMapping("/refresh")
+	public SingleResult<String> refreshToken (HttpServletRequest request, HttpServletResponse response) {
+		// access token 확인
+		String accessToken = jwtTokenProvider.resolveToken((HttpServletRequest)request);
+		if (jwtTokenProvider.validateToken(accessToken)) {
+			throw new NotExpiredTokenYetException();
+			//오류반환
+		}
+
+		Claims claims= jwtTokenProvider.getExpiredTokenClaims(accessToken);
+		String userId = jwtTokenProvider.getUserPk(accessToken);
+		RoleType roleType = RoleType.of(claims.get("role", String.class));
+
+		// refresh token
+		String refreshToken = CookieUtil.getCookie(request, REFRESH_TOKEN)
+			.map(Cookie::getValue)
+			.orElse((null));
+
+
+		if (jwtTokenProvider.validateToken(refreshToken)) {
+			//오류반환
+			throw new NotExpiredTokenYetException();
+		}
+
+		// userId refresh token 으로 DB 확인
+		UserRefreshToken userRefreshToken = userRefreshTokenRepository.findByUserEmailAndRefreshToken(userId, refreshToken);
+		if (userRefreshToken == null) {
+			throw new InvalidRefreshTokenException();
+			//요류반환
+		}
+
+		Date now = new Date();
+		String newAccessToken= jwtTokenProvider.createToken(userId, roleType);
+
+
+		long validTime = jwtTokenProvider.getExpiredTokenClaims(refreshToken).getExpiration().getTime() - now.getTime();
+
+		// refresh 토큰 기간이 3일 이하로 남은 경우, refresh 토큰 갱신
+		if (validTime <= THREE_DAYS_MSEC) {
+			String newRefreshToken= jwtTokenProvider.createRefreshToken(userId, roleType);
+
+			// DB에 refresh 토큰 업데이트
+			userRefreshToken.setRefreshToken(newRefreshToken);
+			long refreshTokenExpiry= jwtTokenProvider.getREFRESH_EXPIRATION();
+			int cookieMaxAge = (int) refreshTokenExpiry / 60;
+			CookieUtil.deleteCookie(request, response, REFRESH_TOKEN);
+			CookieUtil.addCookie(response, REFRESH_TOKEN, newRefreshToken, cookieMaxAge);
+		}
+
+		return responseService.getSingleResult(newAccessToken);
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/jpa/entity/ProviderType.java
+++ b/src/main/java/org/diamond_badge/footprint/jpa/entity/ProviderType.java
@@ -1,0 +1,11 @@
+package org.diamond_badge.footprint.jpa.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ProviderType {
+	GOOGLE,
+	NAVER,
+	KAKAO;
+}
+

--- a/src/main/java/org/diamond_badge/footprint/jpa/entity/RoleType.java
+++ b/src/main/java/org/diamond_badge/footprint/jpa/entity/RoleType.java
@@ -1,0 +1,25 @@
+package org.diamond_badge.footprint.jpa.entity;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RoleType {
+	USER("ROLE_USER", "일반 사용자 권한"),
+	ADMIN("ROLE_ADMIN", "관리자 권한"),
+	GUEST("GUEST", "게스트 권한");
+
+	private final String code;
+	private final String displayName;
+
+	public static RoleType of(String code) {
+		return Arrays.stream(RoleType.values())
+			.filter(r -> r.getCode().equals(code))
+			.findAny()
+			.orElse(GUEST);
+	}
+}
+

--- a/src/main/java/org/diamond_badge/footprint/jpa/entity/User.java
+++ b/src/main/java/org/diamond_badge/footprint/jpa/entity/User.java
@@ -1,0 +1,94 @@
+package org.diamond_badge.footprint.jpa.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "USER")
+public class User {
+	@JsonIgnore
+	@Id
+	@Column(name = "USER_SEQ")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long userSeq;
+
+
+	@Column(name = "USERNAME", length = 100)
+	@NotNull
+	@Size(max = 100)
+	private String username;
+
+	@Column(name = "EMAIL", length = 512, unique = true)
+	@NotNull
+	@Size(max = 512)
+	private String email;
+
+	@Column(name = "PROFILE_IMAGE_URL", length = 512)
+	@NotNull
+	@Size(max = 512)
+	private String profileImageUrl;
+
+	@Column(name = "PROVIDER_TYPE", length = 20)
+	@Enumerated(EnumType.STRING)
+	@NotNull
+	private ProviderType providerType;
+
+	@Column(name = "ROLE_TYPE", length = 20)
+	@Enumerated(EnumType.STRING)
+	@NotNull
+	private RoleType roleType;
+
+	@Column(name = "CREATED_AT")
+	@NotNull
+	private LocalDateTime createdAt;
+
+	@Column(name = "MODIFIED_AT")
+	@NotNull
+	private LocalDateTime modifiedAt;
+
+	public User(
+		@NotNull @Size(max = 100) String username,
+		@NotNull @Size(max = 512) String email,
+		@NotNull @Size(max = 512) String profileImageUrl,
+		@NotNull ProviderType providerType,
+		@NotNull RoleType roleType,
+		@NotNull LocalDateTime createdAt,
+		@NotNull LocalDateTime modifiedAt
+	) {
+		this.username = username;
+		this.email = email != null ? email : "NO_EMAIL";
+		this.profileImageUrl = profileImageUrl != null ? profileImageUrl : "";
+		this.providerType = providerType;
+		this.roleType = roleType;
+		this.createdAt = createdAt;
+		this.modifiedAt = modifiedAt;
+	}
+
+	public void setUsername(String username){
+		this.username=username;
+	}
+
+	public void setProfileImageUrl(String profileImageUrl){
+		this.profileImageUrl=profileImageUrl;
+	}
+}
+

--- a/src/main/java/org/diamond_badge/footprint/jpa/entity/UserRefreshToken.java
+++ b/src/main/java/org/diamond_badge/footprint/jpa/entity/UserRefreshToken.java
@@ -1,0 +1,51 @@
+package org.diamond_badge.footprint.jpa.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "USER_REFRESH_TOKEN")
+public class UserRefreshToken {
+	@JsonIgnore
+	@Id
+	@Column(name = "REFRESH_TOKEN_SEQ")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long refreshTokenSeq;
+
+	@Column(name = "USER_EMAIL", length = 64, unique = true)
+	@NotNull
+	@Size(max = 64)
+	private String userEmail;
+
+	@Column(name = "REFRESH_TOKEN", length = 256)
+	@NotNull
+	@Size(max = 256)
+	private String refreshToken;
+
+	public UserRefreshToken(
+		@NotNull @Size(max = 64) String userEmail,
+		@NotNull @Size(max = 256) String refreshToken
+	) {
+		this.userEmail = userEmail;
+		this.refreshToken = refreshToken;
+	}
+
+	public void setRefreshToken(String refreshToken){
+		this.refreshToken=refreshToken;
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/jpa/repo/UserRefreshTokenRepository.java
+++ b/src/main/java/org/diamond_badge/footprint/jpa/repo/UserRefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package org.diamond_badge.footprint.jpa.repo;
+
+import org.diamond_badge.footprint.jpa.entity.UserRefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
+	UserRefreshToken findByUserEmail(String userEmail);
+	UserRefreshToken findByUserEmailAndRefreshToken(String userEmail, String refreshToken);
+}

--- a/src/main/java/org/diamond_badge/footprint/jpa/repo/UserRepository.java
+++ b/src/main/java/org/diamond_badge/footprint/jpa/repo/UserRepository.java
@@ -1,0 +1,11 @@
+package org.diamond_badge.footprint.jpa.repo;
+
+import java.util.Optional;
+
+import org.diamond_badge.footprint.jpa.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User,Long> {
+	Optional<User> findByEmail(String email);
+}
+

--- a/src/main/java/org/diamond_badge/footprint/model/social/KakaoProfile.java
+++ b/src/main/java/org/diamond_badge/footprint/model/social/KakaoProfile.java
@@ -1,0 +1,31 @@
+package org.diamond_badge.footprint.model.social;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class KakaoProfile {
+	private Long id;
+	private Kakao_properties kakao_properties;
+	private Kakao_account kakao_account;
+
+	@Getter
+	@Setter
+	@ToString
+	public static class Kakao_properties {
+		private String nickname;
+		private String profile_image;
+	}
+
+	@Getter
+	@Setter
+	@ToString
+	public static class Kakao_account {
+		private String email;
+		private String nickname;
+		private String profile_image;
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/model/social/NaverProfile.java
+++ b/src/main/java/org/diamond_badge/footprint/model/social/NaverProfile.java
@@ -1,0 +1,23 @@
+package org.diamond_badge.footprint.model.social;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class NaverProfile {
+	private String resultcode;
+	private String message;
+	private Response response;
+
+	@Getter
+	@Setter
+	@ToString
+	public static class Response {
+		private String id;
+		private String email;
+
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/model/social/RetKakaoAuth.java
+++ b/src/main/java/org/diamond_badge/footprint/model/social/RetKakaoAuth.java
@@ -1,0 +1,25 @@
+package org.diamond_badge.footprint.model.social;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @package : kr.or.dining_together.member.vo
+ * @name: RetKakaoAuth.java
+ * @date : 2021/06/03 1:30 오전
+ * @author : jifrozen
+ * @version : 1.0.0
+ * @description : 카카오 token api 연동시 맵핑을 위한 모델 생성
+ * @modified :
+ **/
+
+@Getter
+@Setter
+public class RetKakaoAuth {
+	private String access_token;
+	private String token_type;
+	private String refresh_token;
+	private long expires_in;
+	private String scope;
+	private long refresh_token_expires_in;
+}

--- a/src/main/java/org/diamond_badge/footprint/model/social/RetNaverAuth.java
+++ b/src/main/java/org/diamond_badge/footprint/model/social/RetNaverAuth.java
@@ -1,0 +1,14 @@
+package org.diamond_badge.footprint.model.social;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RetNaverAuth {
+	private String access_token;
+	private String token_type;
+	private String refresh_token;
+	private Integer expires_in;
+
+}

--- a/src/main/java/org/diamond_badge/footprint/service/CustomUserDetailService.java
+++ b/src/main/java/org/diamond_badge/footprint/service/CustomUserDetailService.java
@@ -1,0 +1,31 @@
+package org.diamond_badge.footprint.service;
+
+import org.diamond_badge.footprint.advice.exception.UserNotFoundException;
+import org.diamond_badge.footprint.jpa.entity.User;
+import org.diamond_badge.footprint.jpa.repo.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	@Transactional(readOnly = true)
+	public UserDetails loadUserByUsername(String email) {
+		//오류 있어서 수정햇는데 잘되는지 확인 필요
+		User user = null;
+		try {
+			user = (User)userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+		} catch (Throwable throwable) {
+			throwable.printStackTrace();
+		}
+		return (UserDetails)user;
+	}
+}

--- a/src/main/java/org/diamond_badge/footprint/service/KakaoService.java
+++ b/src/main/java/org/diamond_badge/footprint/service/KakaoService.java
@@ -1,0 +1,94 @@
+package org.diamond_badge.footprint.service;
+
+import org.diamond_badge.footprint.advice.exception.ComunicationException;
+import org.diamond_badge.footprint.model.social.KakaoProfile;
+import org.diamond_badge.footprint.model.social.RetKakaoAuth;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+	private final RestTemplate restTemplate;
+	private final Environment env;
+	Gson gson = new GsonBuilder().create();
+
+	@Value("${spring.url.base}")
+	private String baseUrl;
+
+	@Value("${spring.social.kakao.clientId}")
+	private String kakaoClientId;
+
+	@Value("${spring.social.kakao.redirectUri}")
+	private String kakaoRedirect;
+
+	@Value("${spring.social.kakao.clientSecret}")
+	private String kakaoSecret;
+
+	/**
+	 * 카카오 플랫폼에서 사용자 정보를 요청한다.
+	 **/
+	public KakaoProfile getKakaoProfile(String accessToken) {
+		// Set header : Content-type: application/x-www-form-urlencoded
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		headers.set("Authorization", "Bearer " + accessToken);
+
+		// Set http entity
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(null, headers);
+		try {
+			// Request profile
+			ResponseEntity<String> response = restTemplate.postForEntity(
+				env.getProperty("spring.social.provider.kakao.userInfoUri"), request, String.class);
+			if (response.getStatusCode() == HttpStatus.OK)
+				return gson.fromJson(response.getBody(), KakaoProfile.class);
+		} catch (Exception e) {
+			throw new ComunicationException();
+		}
+		throw new ComunicationException();
+	}
+
+	/**
+	 * 카카오 플랫폼에서 사용자 토큰을 발급받는다.
+	 **/
+	public RetKakaoAuth getKakaoTokenInfo(String code) {
+		// Set header : Content-type: application/x-www-form-urlencoded
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		// Set parameter
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("grant_type", "authorization_code");
+		params.add("client_id", kakaoClientId);
+		params.add("redirect_uri", "http://localhost:8080/login/oauth2/code/kakao");
+		params.add("code", code);
+		params.add("client_secret", kakaoSecret);
+		System.out.print(params.values().toString());
+		// Set http entity
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+		ResponseEntity<String> response = restTemplate.postForEntity("https://kauth.kakao.com/oauth/token",
+			request, String.class);
+		// return response;
+		System.out.println(response.getStatusCode());
+		if (response.getStatusCode() == HttpStatus.OK) {
+			System.out.println(response.getBody());
+			return gson.fromJson(response.getBody(), RetKakaoAuth.class);
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/org/diamond_badge/footprint/service/NaverService.java
+++ b/src/main/java/org/diamond_badge/footprint/service/NaverService.java
@@ -1,0 +1,137 @@
+package org.diamond_badge.footprint.service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.diamond_badge.footprint.model.social.NaverProfile;
+import org.diamond_badge.footprint.model.social.RetNaverAuth;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import com.google.gson.Gson;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class NaverService {
+
+	private final RestTemplate restTemplate;
+	private final Environment env;
+	private final Gson gson;
+
+	@Value("${spring.url.base}")
+	private String baseUrl;
+
+	@Value("${spring.social.naver.clientId}")
+	private String naverClientId;
+
+	@Value("${spring.social.naver.clientSecret}")
+	private String naverClientSecret;
+
+	@Value("${spring.social.naver.redirectUri}")
+	private String naverRedirect;
+
+	@Value("${spring.social.provider.naver.userInfoUri}")
+	private String naverProfile;
+
+	private static String get(String apiUrl, Map<String, String> requestHeaders) {
+		HttpURLConnection con = connect(apiUrl);
+		try {
+			con.setRequestMethod("GET");
+			for (Map.Entry<String, String> header : requestHeaders.entrySet()) {
+				con.setRequestProperty(header.getKey(), header.getValue());
+			}
+
+			int responseCode = con.getResponseCode();
+			if (responseCode == HttpURLConnection.HTTP_OK) { // 정상 호출
+				return readBody(con.getInputStream());
+			} else { // 에러 발생
+				return readBody(con.getErrorStream());
+			}
+		} catch (IOException e) {
+			throw new RuntimeException("API 요청과 응답 실패", e);
+		} finally {
+			con.disconnect();
+		}
+	}
+
+	private static HttpURLConnection connect(String apiUrl) {
+		try {
+			URL url = new URL(apiUrl);
+			return (HttpURLConnection)url.openConnection();
+		} catch (MalformedURLException e) {
+			throw new RuntimeException("API URL이 잘못되었습니다. : " + apiUrl, e);
+		} catch (IOException e) {
+			throw new RuntimeException("연결이 실패했습니다. : " + apiUrl, e);
+		}
+	}
+
+	private static String readBody(InputStream body) {
+		InputStreamReader streamReader = new InputStreamReader(body);
+
+		try (BufferedReader lineReader = new BufferedReader(streamReader)) {
+			StringBuilder responseBody = new StringBuilder();
+
+			String line;
+			while ((line = lineReader.readLine()) != null) {
+				responseBody.append(line);
+			}
+
+			return responseBody.toString();
+		} catch (IOException e) {
+			throw new RuntimeException("API 응답을 읽는데 실패했습니다.", e);
+		}
+	}
+
+	public NaverProfile getNaverProfile(String accessToken) {
+		String header = "Bearer " + accessToken; // Bearer 다음에 공백 추가
+		System.out.println(header);
+		Map<String, String> requestHeaders = new HashMap<>();
+		requestHeaders.put("Authorization", header);
+		String responseBody = get(naverProfile, requestHeaders);
+		System.out.println(responseBody);
+		return gson.fromJson(responseBody, NaverProfile.class);
+	}
+
+	public RetNaverAuth getNaverTokenInfo(String code) {
+		// Set header : Content-type: application/x-www-form-urlencoded
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+		// Set parameter
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("grant_type", "authorization_code");
+		params.add("client_id", naverClientId);
+		params.add("client_secret", naverClientSecret);
+		params.add("redirect_uri", baseUrl+naverRedirect);
+		params.add("code", code);
+		params.add("state", "footprint");
+		// Set http entity
+		HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+		ResponseEntity<String> response = restTemplate.postForEntity(env.getProperty("spring.social.provider.naver.tokenUri"),
+			request, String.class);
+		System.out.println(response.getStatusCode());
+		if (response.getStatusCode() == HttpStatus.OK) {
+			System.out.println(response.getBody());
+			return gson.fromJson(response.getBody(), RetNaverAuth.class);
+		}
+		return null;
+	}
+}
+

--- a/src/main/java/org/diamond_badge/footprint/service/ResponseService.java
+++ b/src/main/java/org/diamond_badge/footprint/service/ResponseService.java
@@ -52,9 +52,11 @@ public class ResponseService {
 	}
 
 	// 실패 결과만 처리
-	public CommonResult getDefaultFailResult() {
+	public CommonResult getDefaultFailResult(String msg) {
 		CommonResult result = new CommonResult();
-		setFailResult(result);
+		result.setSuccess(false);
+		result.setCode(CommonResponse.FAIL.getCode());
+		result.setMsg(msg);
 		return result;
 	}
 

--- a/src/main/java/org/diamond_badge/footprint/service/UserService.java
+++ b/src/main/java/org/diamond_badge/footprint/service/UserService.java
@@ -1,0 +1,68 @@
+package org.diamond_badge.footprint.service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.diamond_badge.footprint.jpa.entity.ProviderType;
+import org.diamond_badge.footprint.jpa.entity.RoleType;
+import org.diamond_badge.footprint.jpa.entity.User;
+import org.diamond_badge.footprint.jpa.repo.UserRepository;
+import org.diamond_badge.footprint.model.social.KakaoProfile;
+import org.diamond_badge.footprint.model.social.NaverProfile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final KakaoService kakaoService;
+	private final NaverService naverService;
+
+	public User signupByKakao(String accessToken, String provider) {
+		KakaoProfile profile = kakaoService.getKakaoProfile(accessToken);
+		KakaoProfile.Kakao_account kakaoAccount = profile.getKakao_account();
+		System.out.println(String.valueOf(kakaoAccount.getEmail()));
+		Optional<User> user = userRepository.findByEmail(String.valueOf(kakaoAccount.getEmail()));
+		LocalDateTime now=LocalDateTime.now();
+		System.out.println(user.isPresent());
+		if (user.isPresent()) {
+			return user.get();
+		}else {
+			System.out.println(kakaoAccount.getNickname()+" "+ kakaoAccount.getEmail());
+			User kakaoUser=new User(kakaoAccount.getEmail(), kakaoAccount.getEmail(),
+				null, ProviderType.KAKAO, RoleType.USER,now,now);
+
+			return userRepository.save(kakaoUser);
+		}
+	}
+
+
+	public User signupByNaver(String accessToken, String provider) {
+		System.out.print(accessToken);
+		NaverProfile naverProfile = naverService.getNaverProfile(accessToken);
+		NaverProfile.Response naverAccount = naverProfile.getResponse();
+		System.out.print(naverAccount.getEmail());
+		LocalDateTime now=LocalDateTime.now();
+		Optional<User> user = userRepository.findByEmail(naverAccount.getEmail());
+		if (user.isPresent()) {
+			return user.get();
+		} else {
+
+			User naverUser=new User(naverAccount.getId(), naverAccount.getEmail(),null
+				, ProviderType.NAVER, RoleType.USER,now,now);
+
+			userRepository.save(naverUser);
+
+			return naverUser;
+		}
+	}
+
+
+
+}

--- a/src/main/java/org/diamond_badge/footprint/util/CookieUtil.java
+++ b/src/main/java/org/diamond_badge/footprint/util/CookieUtil.java
@@ -1,0 +1,64 @@
+package org.diamond_badge.footprint.util;
+
+import java.util.Base64;
+import java.util.Optional;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.util.SerializationUtils;
+
+public class CookieUtil {
+
+	public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+		Cookie[] cookies = request.getCookies();
+
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (name.equals(cookie.getName())) {
+					return Optional.of(cookie);
+				}
+			}
+		}
+		return Optional.empty();
+	}
+
+	public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+		Cookie cookie = new Cookie(name, value);
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
+		cookie.setMaxAge(maxAge);
+
+		response.addCookie(cookie);
+	}
+
+	public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+		Cookie[] cookies = request.getCookies();
+
+		if (cookies != null && cookies.length > 0) {
+			for (Cookie cookie : cookies) {
+				if (name.equals(cookie.getName())) {
+					cookie.setValue("");
+					cookie.setPath("/");
+					cookie.setMaxAge(0);
+					response.addCookie(cookie);
+				}
+			}
+		}
+	}
+
+	public static String serialize(Object obj) {
+		return Base64.getUrlEncoder()
+			.encodeToString(SerializationUtils.serialize(obj));
+	}
+
+	public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+		return cls.cast(
+			SerializationUtils.deserialize(
+				Base64.getUrlDecoder().decode(cookie.getValue())
+			)
+		);
+	}
+
+}

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -1,0 +1,49 @@
+spring:
+  jwt:
+    secret: 926D96C90030DD58429D2751AC1BDBBC
+    expiration_time: 1800000
+    refreshTokenExpiry: 604800000
+  # Security OAuth
+  url:
+    base: http://localhost:8080
+  social:
+    google:
+      clientId: '774708555233-fcc5lbftt9v8m861vjhuduhp45gtcps5.apps.googleusercontent.com'
+      clientSecret: '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'
+      scope:
+        - email
+        - profile
+    naver:
+      clientId: 'TMhSMPDrwSW4RIt1KM0a'
+      clientSecret: 'SG42oKEsrX'
+      clientAuthenticationMethod: post
+      authorizationGrantType: authorization_code
+      redirectUri: /login/oauth2/code/naver
+      scope:
+        - nickname
+        - email
+        - profile_image
+      clientName: Naver
+    kakao:
+      clientId: '71d5ce469a98fb6ab26bcaf09f3335b0'
+      clientSecret: 'g68eSS5ywEHN3uxrrD6nRNoKFz9wTZVK'
+      clientAuthenticationMethod: post
+      authorizationGrantType: authorization_code
+      redirectUri: /login/oauth2/code/kakao
+      scope:
+        - profile_nickname
+        - profile_image
+        - account_email
+      clientName: Kakao
+    # Provider 설정
+    provider:
+      naver:
+        authorizationUri: https://nid.naver.com/oauth2.0/authorize
+        tokenUri: https://nid.naver.com/oauth2.0/token
+        userInfoUri: https://openapi.naver.com/v1/nid/me
+        userNameAttribute: response
+      kakao:
+        authorizationUri: https://kauth.kakao.com/oauth/authorize
+        tokenUri: https://kauth.kakao.com/oauth/token
+        userInfoUri: https://kapi.kakao.com/v2/user/me
+        userNameAttribute: id

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    include: oauth2
   datasource:
     url: jdbc:h2:mem://localhost/~/test
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
# 소셜 로그인
1. jwt 생성
https://velog.io/@jifrozen/Dining-together-Spring-Security-로그인-회원가입-구현
Access Token 유효기간 문제는 RefreshToken 으로 해결할 예정인데 db에 일단 저장만 구현했고 refreshToken 을 이용해서 AccessToken 을   다시 받는건 잘 안되어서 나중에 완료 할 예정입니다.
참고 https://deeplify.dev/back-end/spring/oauth2-social-login
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/62784314/142582388-50e2df70-9500-4ce7-864b-c620256f4ab7.png">

2. kakao / Naver Login
(https://velog.io/@jifrozen/Dining-together-oauth-소셜-로그인카카오-네이버)
이전과 동일하게 인가코드를 백엔드에서 넘겨주면 토큰을 만들어 우리 프로젝트의 토큰으로 교환해 넘겨주는 식으로 구현했습니다.
로그인 하자마자 AccessToken 값을 return 하고 RefreshToken 을 생성해 Db에 저장했습니다.
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/62784314/142582418-4de529da-875b-480e-8ea8-cd6db2e269f1.png">
