### PR TITLE
[Feat] refreshToken

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,16 +1,13 @@
 ---
-name: Bug report
-about: Create a report to help us improve
-title: "[BUG]"
-labels: 'Status : Bug'
-assignees: ''
+name: Bug report about: Create a report to help us improve title: "[BUG]"
+labels: 'Status : Bug' assignees: ''
 
 ---
 
 **버그 설명**
 
-
 **재현**
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -18,11 +15,10 @@ assignees: ''
 
 **해결 방법**
 
-
 **Screenshots**
 
-
 **Desktop**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,17 +1,16 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
-title: ''
+name: Feature request about: Suggest an idea for this project title: ''
 labels: ''
 assignees: ''
 
 ---
 
 ## Product backlog
+
 - 제목
 
 ## Description
+
 - 설명
 
--[] todo1
--[] todo2
+-[] todo1 -[] todo2

--- a/src/main/java/org/diamond_badge/footprint/config/security/JwtTokenProvider.java
+++ b/src/main/java/org/diamond_badge/footprint/config/security/JwtTokenProvider.java
@@ -104,14 +104,13 @@ public class JwtTokenProvider {
 
 	public Claims getExpiredTokenClaims(String jwtToken) {
 		try {
-			Jwts.parserBuilder()
+			return Jwts.parserBuilder()
 				.setSigningKey(SECRET_KEY)
 				.build()
 				.parseClaimsJws(jwtToken)
 				.getBody();
 		} catch (ExpiredJwtException e) {
 			log.info("Expired JWT token.");
-			return e.getClaims();
 		}
 		return null;
 	}


### PR DESCRIPTION
## refreshToken 을 이용해서 유효기간이 지난 accessToken 을 다시 생성하기
<img width="1025" alt="스크린샷 2021-11-26 오후 9 30 06" src="https://user-images.githubusercontent.com/62784314/143581373-87792924-8b18-4e5a-ad84-ed28861b3adf.png">
bearer token으로 전송 헤더 Authorization에 accessToken이 cookie에 refreshToken 이 보관되어있어야함
<img width="999" alt="image" src="https://user-images.githubusercontent.com/62784314/143581522-3c617951-1044-4491-a6cf-956f79709b34.png">
<img width="1030" alt="스크린샷 2021-11-26 오후 9 30 11" src="https://user-images.githubusercontent.com/62784314/143581377-6c6bb529-3257-436e-8554-e5ed35cec2e2.png">

참고문서
https://deeplify.dev/back-end/spring/oauth2-social-login#applicationyml


